### PR TITLE
Change to using view model instead of domain model in OrderDetails

### DIFF
--- a/Anlab.Core/Models/OrderDetails.cs
+++ b/Anlab.Core/Models/OrderDetails.cs
@@ -7,16 +7,11 @@ namespace Anlab.Core.Models
 {
     public class OrderDetails
     {
-        public OrderDetails()
-        {
-
-        }
-
         public int Quantity { get; set; }
         public string SampleType { get; set; }
         [DataType(DataType.MultilineText)]
         public string AdditionalInfo { get; set; }
-        public IList<TestItem> SelectedTests { get; set; }
+        public IList<TestDetails> SelectedTests { get; set; }
 
         public Decimal Total { get; set; }
 

--- a/Anlab.Core/Models/Payment.cs
+++ b/Anlab.Core/Models/Payment.cs
@@ -10,5 +10,7 @@ namespace Anlab.Core.Models
         [Required(ErrorMessage = "You must select the payment method.")]
         public string ClientType { get; set; }
         public string Account { get; set; }
+
+        public bool IsInternalClient => string.Equals(ClientType, "uc", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Anlab.Core/Models/TestDetails.cs
+++ b/Anlab.Core/Models/TestDetails.cs
@@ -2,6 +2,8 @@
 {
     public class TestDetails
     {
+        //TODO: See about dumping ID here in case they change
+        public int Id { get; set; }
         public string Analysis { get; set; }
 
         public string Code { get; set; }

--- a/Anlab.Core/Models/TestDetails.cs
+++ b/Anlab.Core/Models/TestDetails.cs
@@ -1,0 +1,26 @@
+﻿namespace Anlab.Core.Models
+{
+    public class TestDetails
+    {
+        public string Analysis { get; set; }
+
+        public string Code { get; set; }
+
+        public decimal InternalCost { get; set; }
+
+        public decimal ExternalCost { get; set; }
+
+        // The cost to run this test for one sample
+        public decimal Cost { get; set; }
+
+        // Setup cost
+        public decimal SetupCost { get; set; }
+
+        // Cost for all runs of this sample (Cost * Quantity)
+        public decimal SubTotal { get; set; }
+
+        // SubTotal + SetupCost
+        public decimal Total { get; set; }
+ 
+    }
+}

--- a/Anlab.Mvc/Controllers/OrderController.cs
+++ b/Anlab.Mvc/Controllers/OrderController.cs
@@ -1,19 +1,13 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Anlab.Core.Data;
 using AnlabMvc.Models.Order;
 using Anlab.Core.Domain;
-using Anlab.Core.Models;
 using AnlabMvc.Services;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Remotion.Linq.Parsing.ExpressionVisitors.MemberBindings;
 
 namespace AnlabMvc.Controllers
 {

--- a/Anlab.Mvc/Models/Order/OrderSaveModel.cs
+++ b/Anlab.Mvc/Models/Order/OrderSaveModel.cs
@@ -18,7 +18,7 @@ namespace AnlabMvc.Models.Order
         public string AdditionalInfo { get; set; }
 
         [MinLength(1, ErrorMessage = "You must select at least 1 test.")]
-        public TestItem[] SelectedTests { get; set; }
+        public TestDetails[] SelectedTests { get; set; }
 
         public decimal Total { get; set; }
 

--- a/Anlab.Mvc/Services/IOrderService.cs
+++ b/Anlab.Mvc/Services/IOrderService.cs
@@ -29,20 +29,22 @@ namespace AnlabMvc.Services
 
         private async Task<TestDetails[]> CalculateTestDetails(OrderDetails orderDetails)
         {
-            var selectedTestCodes = orderDetails.SelectedTests.Select(t => t.Code);
-            var tests = await _context.TestItems.Where(a => selectedTestCodes.Contains(a.Code)).ToListAsync();
+            // TODO: Do we really want to match on ID, or Code, or some combination?
+            var selectedTestIds = orderDetails.SelectedTests.Select(t => t.Id);
+            var tests = await _context.TestItems.Where(a => selectedTestIds.Contains(a.Id)).ToListAsync();
 
             var calcualtedTests = new List<TestDetails>();
 
             foreach (var test in orderDetails.SelectedTests)
             {
-                var dbTest = tests.Single(t => t.Code == test.Code);
+                var dbTest = tests.Single(t => t.Id == test.Id);
 
                 var cost = orderDetails.Payment.IsInternalClient ? dbTest.InternalCost : dbTest.ExternalCost;
                 var costAndQuantity = cost * orderDetails.Quantity;
 
                 calcualtedTests.Add(new TestDetails
                 {
+                    Id = dbTest.Id,
                     Analysis = dbTest.Analysis,
                     Code = dbTest.Code,
                     SetupCost = dbTest.SetupCost,

--- a/Anlab.Mvc/Views/Shared/_OrderDetails.cshtml
+++ b/Anlab.Mvc/Views/Shared/_OrderDetails.cshtml
@@ -85,17 +85,13 @@
     <tbody>
         @foreach (var test in @Model.OrderDetails.SelectedTests)
         {
-            var testFee = string.Equals(Model.OrderDetails.Payment.ClientType, "uc", StringComparison.OrdinalIgnoreCase) ? test.InternalCost : test.ExternalCost;
-            var totalForTest = (testFee * Model.OrderDetails.Quantity) + test.SetupCost;
             <tr>
                 <td>@test.Analysis</td>
                 <td>@test.Code</td>
-                <td>@(String.Format("{0:C}", testFee * Model.OrderDetails.Quantity))</td>
-                <td>@(String.Format("{0:C}", test.SetupCost))</td>
-                <td>
-                    @(String.Format("{0:C}", totalForTest))
-            </td>
-        </tr>
+                <td>@test.SubTotal.ToString("C")</td>
+                <td>@test.SetupCost.ToString("C")</td>
+                <td>@test.Total.ToString("C")</td>
+            </tr>
         }
     </tbody>
 </table>


### PR DESCRIPTION
Main benefit is we can decouple the calculation from the domain object (which isn't intended to be part of an order).  Should make confirmation pages and emails easier too since we don't have to recalculate to display every time.  