### PR TITLE
Fix the summary not sticky when in browse

### DIFF
--- a/Anlab.Mvc/Client/css/regions.scss
+++ b/Anlab.Mvc/Client/css/regions.scss
@@ -25,6 +25,7 @@
   z-index:99;
 }
 .stickyfoot {
+    position:sticky;
     left: 0;
     width: 100%;
 }


### PR DESCRIPTION
When it wasn't sticking, noticed it had a style="Position: relative;"
This clears that out.