### PR TITLE
use current action context for rendering view

### DIFF
--- a/Anlab.Mvc/Services/ViewRenderService.cs
+++ b/Anlab.Mvc/Services/ViewRenderService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -20,22 +21,25 @@ namespace AnlabMvc.Services
         private IRazorViewEngine _viewEngine;
         private ITempDataProvider _tempDataProvider;
         private IServiceProvider _serviceProvider;
+        private IActionContextAccessor _actionContextAccessor;
 
         public ViewRenderService(
             IRazorViewEngine viewEngine,
             ITempDataProvider tempDataProvider,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            IActionContextAccessor actionContextAccessor)
         {
             _viewEngine = viewEngine;
             _tempDataProvider = tempDataProvider;
             _serviceProvider = serviceProvider;
+            _actionContextAccessor = actionContextAccessor;
         }
 
         public async Task<string> RenderViewToStringAsync<TModel>(string name, TModel model)
         {
-            var actionContext = GetActionContext();
+            var actionContext = _actionContextAccessor.ActionContext;
 
-            var viewEngineResult = _viewEngine.FindView(actionContext, name, false);
+            var viewEngineResult = _viewEngine.FindView(GetDefaultActionContext(), name, false);
 
             if (!viewEngineResult.Success)
             {
@@ -67,7 +71,7 @@ namespace AnlabMvc.Services
             }
         }
 
-        private ActionContext GetActionContext()
+        private ActionContext GetDefaultActionContext()
         {
             var httpContext = new DefaultHttpContext();
             httpContext.RequestServices = _serviceProvider;

--- a/Anlab.Mvc/Startup.cs
+++ b/Anlab.Mvc/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.SpaServices.Webpack;
 using Microsoft.EntityFrameworkCore;
@@ -129,6 +130,7 @@ namespace AnlabMvc
             services.AddTransient<IFileStorageService, FileStorageService>();
             services.AddSingleton<IDataSigningService, DataSigningService>();
             services.AddTransient<IFinancialService, FinancialService>();
+            services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
use default context to reliably find the view

now you can use any action context related stuff, including to add an action link:

```
<a asp-action="Index" asp-controller="Home" asp-protocol="@Url.ActionContext.HttpContext.Request.Scheme">click me</a>
```