### PR TITLE
Logout

### DIFF
--- a/Anlab.Mvc/Controllers/AccountController.cs
+++ b/Anlab.Mvc/Controllers/AccountController.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Serilog;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
@@ -29,6 +30,7 @@ namespace AnlabMvc.Controllers
         private readonly IDirectorySearchService _directorySearchService;
         private readonly ILogger _logger;
         private readonly ILabworksService _labworksService;
+        private readonly AppSettings _appSettings;
 
         public AccountController(
             UserManager<User> userManager,
@@ -36,7 +38,8 @@ namespace AnlabMvc.Controllers
             IEmailSender emailSender,
             IDirectorySearchService directorySearchService,
             ILogger<AccountController> logger,
-            ILabworksService labworksService)
+            ILabworksService labworksService,
+            IOptions<AppSettings> appSettings)
         {
             _userManager = userManager;
             _signInManager = signInManager;
@@ -44,6 +47,7 @@ namespace AnlabMvc.Controllers
             _directorySearchService = directorySearchService;
             _logger = logger;
             _labworksService = labworksService;
+            _appSettings = appSettings.Value;
         }
 
         [TempData]
@@ -270,7 +274,7 @@ namespace AnlabMvc.Controllers
                 return Redirect(url);
             }
 
-            return Redirect($"https://ssodev.ucdavis.edu/cas/logout"); //Replace with the appSettings if we do it this way.
+            return Redirect($"{_appSettings.CasBaseUrl}logout"); //Replace with the appSettings if we do it this way.
 
         }
 

--- a/Anlab.Mvc/Controllers/AccountController.cs
+++ b/Anlab.Mvc/Controllers/AccountController.cs
@@ -254,9 +254,24 @@ namespace AnlabMvc.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Logout()
         {
+            var provider = User.FindFirst(ClaimTypes.AuthenticationMethod)?.Value;
+
             await _signInManager.SignOutAsync();
-            _logger.LogInformation("User logged out.");
-            return RedirectToAction(nameof(HomeController.Index), "Home");
+
+            if (string.IsNullOrWhiteSpace(provider))
+            {
+                _logger.LogInformation("User logged out.");
+                return RedirectToAction(nameof(HomeController.Index), "Home");
+            }
+            var returnUrl = Url.Action("Index", "Home", null, Request.Scheme);
+            if (provider.Equals("Google", StringComparison.OrdinalIgnoreCase))
+            {
+                var url = $"https://www.google.com/accounts/Logout?continue=https://appengine.google.com/_ah/logout?continue={returnUrl}";
+                return Redirect(url);
+            }
+
+            return Redirect($"https://ssodev.ucdavis.edu/cas/logout"); //Replace with the appSettings if we do it this way.
+
         }
 
         public async Task<IActionResult> LogoutDirect()

--- a/Anlab.Mvc/Controllers/AccountController.cs
+++ b/Anlab.Mvc/Controllers/AccountController.cs
@@ -261,19 +261,22 @@ namespace AnlabMvc.Controllers
             var provider = User.FindFirst(ClaimTypes.AuthenticationMethod)?.Value;
 
             await _signInManager.SignOutAsync();
-
+            _logger.LogInformation("User logged out.");
             if (string.IsNullOrWhiteSpace(provider))
             {
-                _logger.LogInformation("User logged out.");
+                //This should never happen.
                 return RedirectToAction(nameof(HomeController.Index), "Home");
             }
-            var returnUrl = Url.Action("Index", "Home", null, Request.Scheme);
+
+            
             if (provider.Equals("Google", StringComparison.OrdinalIgnoreCase))
             {
+                var returnUrl = Url.Action("Index", "Home", null, Request.Scheme);
                 var url = $"https://www.google.com/accounts/Logout?continue=https://appengine.google.com/_ah/logout?continue={returnUrl}";
                 return Redirect(url);
             }
 
+            //CAS logout does not support a redirect. They thought it was a security risk
             return Redirect($"{_appSettings.CasBaseUrl}logout"); //Replace with the appSettings if we do it this way.
 
         }


### PR DESCRIPTION
@srkirkland This works (would need to pass in the app settings for the CAS URL). But I feel that the logout stuff should be setup in the startup file. But, I'm not sure how to do that.
When I use @jpknoll 's code, I get exceptions like

`InvalidOperationException: No IAuthenticationSignOutHandler is configured to handle sign out for the scheme: Google`

Note: It looks like CAS has the logout redirect disabled so that wouldn't work anyway.