### PR TITLE
keep react-datepicker at an older version since the newer one breaks

### DIFF
--- a/Anlab.Mvc/package.json
+++ b/Anlab.Mvc/package.json
@@ -11,7 +11,7 @@
     "moment": "^2.20.1",
     "react": "^15.6.2",
     "react-bootstrap": "^0.31.5",
-    "react-datepicker": "^1.1.0",
+    "react-datepicker": "1.4.1",
     "react-dom": "^15.6.2",
     "react-hot-loader": "^3.1.3",
     "react-number-format": "^2.0.4",


### PR DESCRIPTION
https://github.com/Hacker0x01/react-datepicker/issues/1521

we could also replace it with a freeform text field re: this issue 
https://github.com/ucdavis/Anlab/issues/617