### PR TITLE
Fix resend when there are failures

### DIFF
--- a/Anlab.Mvc/Controllers/AdminController.cs
+++ b/Anlab.Mvc/Controllers/AdminController.cs
@@ -251,9 +251,10 @@ namespace AnlabMvc.Controllers
                 if (model.Resend)
                 {
                     mm.Sent = null;
+                    mm.FailureCount = 0;
                 }
 
-                var extraMessage = mm.Sent == null
+                var extraMessage = model.Resend
                     ? "The mail message will attempt to send again."
                     : "You did not choose to try and re-send";
 

--- a/Anlab.Mvc/Views/Admin/FixEmail.cshtml
+++ b/Anlab.Mvc/Views/Admin/FixEmail.cshtml
@@ -20,7 +20,7 @@
                 <strong>Failure Count</strong>
                 <span>@Model.FailureCount</span>
             </div>
-            @if (Model.Sent != null && Model.Sent.Value == false)
+            @if ((Model.Sent != null && Model.Sent.Value == false) || Model.FailureCount > 2)
             {
                 <div class="form-group">
                     <strong>Last Failure Reason</strong>

--- a/Anlab.Mvc/Views/Admin/MailQueue.cshtml
+++ b/Anlab.Mvc/Views/Admin/MailQueue.cshtml
@@ -44,15 +44,15 @@ else
         <tr>
             <td></td>
             <td>
-                @if (message.Sent.HasValue)
+                @if (message.Sent.HasValue || message.FailureCount > 2)
                 {
                     <a asp-controller="Admin" asp-action="FixEmail" asp-route-id="@message.Id">Edit</a>
                 }
             </td>
             <td>
-                @if (message.Sent.HasValue)
+                @if (message.Sent.HasValue || message.FailureCount > 2)
                 {
-                    if (message.Sent.Value)
+                    if (message.Sent.HasValue && message.Sent.Value)
                     {
                         <span data-toggle="tooltip" title="Sent"><i class="fa fa-check-circle" aria-hidden="true"></i> Sent</span>
                     }


### PR DESCRIPTION
An email may have never sent (null) and have a failure count of 3 which will prevent any resends.
This lets that be fixed so it can try sending again.
Closes Issue #936