### PR TITLE
Updates row highlighting with Bootstrap 5 classes

### DIFF
--- a/Anlab.Mvc/Views/Order/Favorites.cshtml
+++ b/Anlab.Mvc/Views/Order/Favorites.cshtml
@@ -99,10 +99,10 @@
                 "stateDuration": 60 * 10,
                 "createdRow": function(row, data, index) {
                     if (data[3] == "Created") {
-                        $(row).addClass('warning');
+                        $(row).addClass('table-warning');
                     }
                     if (data[3] == "Finalized" && !data[4]) {
-                        $(row).addClass('danger');
+                        $(row).addClass('table-danger');
                     }
                 }
             });

--- a/Anlab.Mvc/Views/Order/Index.cshtml
+++ b/Anlab.Mvc/Views/Order/Index.cshtml
@@ -150,11 +150,11 @@
                  "createdRow": function (row, data, index) {
                      if (data[3] == "Created")
                      {
-                         $(row).addClass('warning');
+                         $(row).addClass('table-warning');
                      }
                      if (data[3] == "Finalized" && !data[4])
                      {
-                         $(row).addClass('danger');
+                         $(row).addClass('table-danger');
                      }
                  }
              });


### PR DESCRIPTION
Updates the row highlighting classes to use Bootstrap 5's "table-" prefixed classes. This ensures compatibility with Bootstrap 5's styling conventions for table rows, specifically for warning and danger states.