### PR TITLE
Enhances plant reporting basis instructions

### DIFF
--- a/Anlab.Mvc/ClientApp/src/components/SamplePlantQuestions.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/SamplePlantQuestions.tsx
@@ -111,9 +111,14 @@ export class SamplePlantQuestions extends React.Component<
             )}
         </p>
         {!this.props.questions.plantReportingBasis && (
-          <span className="red-text help-block">
-            You must select how you would like your samples reported.
-          </span>
+          <>
+            <span className="red-text help-block">
+              You must select how you would like your samples reported.
+            </span>
+            <span className="red-text help-block">
+              Choose 'As Received' if the moisture factor is not applicable.
+            </span>
+          </>
         )}
         {((this.props.questions.plantReportingBasis ===
           SamplePlantQuestionsOptions.average &&


### PR DESCRIPTION
Adds a message clarifying the 'As Received' reporting basis.

The additional message helps users understand when to choose the 'As Received' option if the moisture factor is not applicable.