### PR TITLE
Adds help text to Client ID modal regarding ID generation

### DIFF
--- a/Anlab.Mvc/AnlabMvc.csproj
+++ b/Anlab.Mvc/AnlabMvc.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
+<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
@@ -6,7 +6,7 @@
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
     <UserSecretsId>f3c999a5-2304-44e0-a49e-f43333bf9ccf</UserSecretsId>
-    <Version>2.0.3.1</Version>
+    <Version>2.0.3.2</Version>
     <Description>Order and results management system for AnLab@UCDavis</Description>
     <TypeScriptToolsVersion>2.3</TypeScriptToolsVersion>
   </PropertyGroup>

--- a/Anlab.Mvc/ClientApp/src/components/ClientIdModal.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/ClientIdModal.tsx
@@ -63,6 +63,11 @@ export class ClientIdModal extends React.Component<
             <Modal.Title>{title}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
+            <p className="help-block">
+              Please note: The ID will be generated and connected to your
+              samples upon receipt of your samples. It will not automatically
+              fill in the form here.
+            </p>
             <ClientIdModalInput
               property="name"
               value={this.props.clientInfo.name}


### PR DESCRIPTION
Clarifies that the ID will be generated upon receipt of samples and will not automatically fill the form.

Addressing INC2549412

<img width="885" height="1264" alt="image" src="https://github.com/user-attachments/assets/976b608f-399f-4ab1-b0c5-14eed8946cb1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added informational message clarifying that Client IDs are generated upon receipt of samples and will not auto-fill the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->