### PR TITLE
Increases maximum samples per order to 200

### DIFF
--- a/Anlab.Mvc/AnlabMvc.csproj
+++ b/Anlab.Mvc/AnlabMvc.csproj
@@ -6,7 +6,7 @@
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
     <UserSecretsId>f3c999a5-2304-44e0-a49e-f43333bf9ccf</UserSecretsId>
-    <Version>2.0.3.2</Version>
+    <Version>2.0.3.3</Version>
     <Description>Order and results management system for AnLab@UCDavis</Description>
     <TypeScriptToolsVersion>2.3</TypeScriptToolsVersion>
   </PropertyGroup>

--- a/Anlab.Mvc/ClientApp/src/components/OrderForm.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/OrderForm.tsx
@@ -25,6 +25,7 @@ import Summary from "./Summary";
 import { ITestItem, TestList } from "./TestList";
 import { ViewMode } from "./ViewMode";
 import { SamplePlantQuestionsOptions } from "./SamplePlantQuestions";
+import Input from "./ui/input/input";
 
 declare var $: any;
 
@@ -643,10 +644,7 @@ export default class OrderForm extends React.Component<
     }
 
     // check quantity
-    if (
-      this.state.quantity <= 0 ||
-      this.state.quantity > ORDER_QUANTITY_MAX
-    ) {
+    if (this.state.quantity <= 0 || this.state.quantity > ORDER_QUANTITY_MAX) {
       valid = false;
     }
 

--- a/Anlab.Mvc/ClientApp/src/components/OrderForm.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/OrderForm.tsx
@@ -15,7 +15,7 @@ import {
 import { IPayment, PaymentSelection } from "./PaymentSelection";
 import { IOtherPaymentInfo } from "./OtherPaymentQuestions";
 import { Project } from "./Project";
-import { Quantity } from "./Quantity";
+import { ORDER_QUANTITY_MAX, Quantity } from "./Quantity";
 import {
   ISampleTypeQuestions,
   SampleTypeQuestions,
@@ -442,8 +442,9 @@ export default class OrderForm extends React.Component<
                   How many samples will you be submitting?
                 </label>
                 <p className="help-block">
-                  Note: 100 sample limit per work order. If submitting more than
-                  100 sample please create additional work orders.
+                  Note: {ORDER_QUANTITY_MAX} sample limit per work order. If
+                  submitting more than {ORDER_QUANTITY_MAX} samples please
+                  create additional work orders.
                 </p>
                 <p className="help-block">
                   Each sample container must be numbered consecutively beginning
@@ -608,7 +609,10 @@ export default class OrderForm extends React.Component<
     }
 
     // check quantity
-    if (this.state.quantity <= 0 || this.state.quantity > 100) {
+    if (
+      this.state.quantity <= 0 ||
+      this.state.quantity > ORDER_QUANTITY_MAX
+    ) {
       valid = false;
     }
 
@@ -936,7 +940,10 @@ export default class OrderForm extends React.Component<
       !this.state.sampleDisposition.trim()
     ) {
       this._focusInput(this.sampleDispositionRef);
-    } else if (this.state.quantity <= 0 || this.state.quantity > 100) {
+    } else if (
+      this.state.quantity <= 0 ||
+      this.state.quantity > ORDER_QUANTITY_MAX
+    ) {
       this._focusInput(this.quantityRef);
     } else if (
       (this.state.sampleType === "Water" ||

--- a/Anlab.Mvc/ClientApp/src/components/Quantity.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/Quantity.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { IntegerInput } from "./ui/integerInput/integerInput";
 
+export const ORDER_QUANTITY_MAX = 200;
+
 interface IQuantityProps {
   quantity?: number;
   onQuantityChanged: (value: number) => void;
@@ -16,7 +18,7 @@ export class Quantity extends React.Component<IQuantityProps, {}> {
         value={this.props.quantity}
         onChange={this.props.onQuantityChanged}
         min={1}
-        max={100}
+        max={ORDER_QUANTITY_MAX}
         required={true}
         inputRef={this.props.quantityRef}
       />

--- a/Anlab.Mvc/ClientApp/src/components/specs/Quantity.test.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/specs/Quantity.test.tsx
@@ -1,7 +1,19 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { Quantity } from "../Quantity";
+
+const QuantityHarness = () => {
+  const [quantity, setQuantity] = React.useState<number>();
+  return (
+    <Quantity
+      quantity={quantity}
+      onQuantityChanged={setQuantity}
+      quantityRef={() => {}}
+    />
+  );
+};
 
 describe("<Quantity />", () => {
   it("should render an IntegerInput", () => {
@@ -36,6 +48,28 @@ describe("<Quantity />", () => {
         <Quantity quantity={33} onQuantityChanged={null} quantityRef={null} />
       );
       expect(screen.getByRole("textbox")).toHaveAttribute("required");
+    });
+
+    it("should allow 200 samples", async () => {
+      render(<QuantityHarness />);
+
+      const user = userEvent.setup();
+      await user.type(screen.getByRole("textbox"), "200");
+
+      expect(
+        screen.queryByText("Must be a number less than or equal to 200.")
+      ).not.toBeInTheDocument();
+    });
+
+    it("should reject more than 200 samples", async () => {
+      render(<QuantityHarness />);
+
+      const user = userEvent.setup();
+      await user.type(screen.getByRole("textbox"), "201");
+
+      expect(
+        screen.getByText("Must be a number less than or equal to 200.")
+      ).toBeInTheDocument();
     });
   });
 });

--- a/Anlab.Mvc/ClientApp/src/components/specs/Quantity.test.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/specs/Quantity.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { Quantity } from "../Quantity";
+import { ORDER_QUANTITY_MAX, Quantity } from "../Quantity";
 
 const QuantityHarness = () => {
   const [quantity, setQuantity] = React.useState<number>();
@@ -24,6 +24,10 @@ describe("<Quantity />", () => {
   });
 
   describe("properties", () => {
+    it("should have a max quantity of 200", () => {
+      expect(ORDER_QUANTITY_MAX).toBe(200);
+    });
+
     it("should have a name", () => {
       render(
         <Quantity quantity={1} onQuantityChanged={null} quantityRef={null} />
@@ -54,10 +58,12 @@ describe("<Quantity />", () => {
       render(<QuantityHarness />);
 
       const user = userEvent.setup();
-      await user.type(screen.getByRole("textbox"), "200");
+      await user.type(screen.getByRole("textbox"), String(ORDER_QUANTITY_MAX));
 
       expect(
-        screen.queryByText("Must be a number less than or equal to 200.")
+        screen.queryByText(
+          `Must be a number less than or equal to ${ORDER_QUANTITY_MAX}.`
+        )
       ).not.toBeInTheDocument();
     });
 
@@ -65,10 +71,15 @@ describe("<Quantity />", () => {
       render(<QuantityHarness />);
 
       const user = userEvent.setup();
-      await user.type(screen.getByRole("textbox"), "201");
+      await user.type(
+        screen.getByRole("textbox"),
+        String(ORDER_QUANTITY_MAX + 1)
+      );
 
       expect(
-        screen.getByText("Must be a number less than or equal to 200.")
+        screen.getByText(
+          `Must be a number less than or equal to ${ORDER_QUANTITY_MAX}.`
+        )
       ).toBeInTheDocument();
     });
   });

--- a/Anlab.Mvc/ClientApp/src/css/components.scss
+++ b/Anlab.Mvc/ClientApp/src/css/components.scss
@@ -367,6 +367,10 @@ table.table {
   color: $unitrans-red;
 }
 
+.text-error {
+  color: $unitrans-red;
+}
+
 .inline-block {
   padding-left: 1em;
   display: inline-block;

--- a/Anlab.Mvc/Models/Order/OrderSaveModel.cs
+++ b/Anlab.Mvc/Models/Order/OrderSaveModel.cs
@@ -10,7 +10,7 @@ namespace AnlabMvc.Models.Order
     {
 
         public int? OrderId { get; set; }
-        [Range(1, 100)]
+        [Range(1, 200)]
         public int Quantity { get; set; }
 
         [Required]

--- a/Test/TestsController/OrderControllerTests.cs
+++ b/Test/TestsController/OrderControllerTests.cs
@@ -19,6 +19,7 @@ using Newtonsoft.Json.Linq;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
@@ -300,6 +301,9 @@ namespace Test.TestsController
             OrderData[1].CreatorId = "Creator1";
             OrderData[1].Status = OrderStatusCodes.Created;
             OrderData[1].Creator = CreateValidEntities.User(7);
+            var orderDetails = CreateValidEntities.OrderDetails(2);
+            orderDetails.Quantity = 200;
+            OrderData[1].SaveDetails(orderDetails);
 
             // Act
             var controllerResult = await Controller.Edit(2);
@@ -312,6 +316,7 @@ namespace Test.TestsController
             var model = Assert.IsType<OrderEditModel>(result.Model);
             model.Order.ShouldNotBeNull();
             model.Order.Id.ShouldBe(2);
+            model.Order.GetOrderDetails().Quantity.ShouldBe(200);
             model.TestItems.Length.ShouldBe(10);
             model.InternalProcessingFee.ShouldBe(6m);
             model.ExternalProcessingFee.ShouldBe(12m);
@@ -341,6 +346,9 @@ namespace Test.TestsController
 
 
             var copiedOrder = CreateValidEntities.Order(7);
+            var orderDetails = CreateValidEntities.OrderDetails(7);
+            orderDetails.Quantity = 200;
+            copiedOrder.SaveDetails(orderDetails);
             copiedOrder.Creator = CreateValidEntities.User(5, true);
             OrderData[1].CreatorId = "xxx";
             OrderData[1].Creator = CreateValidEntities.User(5);
@@ -358,6 +366,7 @@ namespace Test.TestsController
             savedResult.Creator.Id.ShouldBe("Creator1");
             savedResult.ShareIdentifier.ShouldNotBe(SpecificGuid.GetGuid(2));
             savedResult.SavedTestDetails.ShouldBeNull();
+            savedResult.GetOrderDetails().Quantity.ShouldBe(200);
 
             var redirectResult = Assert.IsType<RedirectToActionResult>(controllerResult);
             redirectResult.ActionName.ShouldBe("Edit");
@@ -525,6 +534,72 @@ namespace Test.TestsController
             MockDbContext.Verify(a => a.SaveChangesAsync(new CancellationToken()), Times.Once);
             OrderData[1].SavedTestDetails.ShouldNotBeNull();
             OrderData[1].GetTestDetails().Count.ShouldBe(10);
+        }
+
+        [Fact]
+        public async Task TestSaveWhenEditAndQuantityIs200Succeeds()
+        {
+            // Arrange
+            OrderData[1].Status = OrderStatusCodes.Created;
+            OrderData[1].CreatorId = "Creator1";
+            var model = CreateValidOrderSaveModel(200);
+            model.OrderId = 2;
+            ValidateModelIntoModelState(model);
+
+            // Act
+            var controllerResult = await Controller.Save(model);
+
+            // Assert
+            var result = Assert.IsType<JsonResult>(controllerResult);
+            dynamic data = JObject.FromObject(result.Value);
+            ((bool)data.success).ShouldBe(true);
+            ((int)data.id).ShouldBe(2);
+
+            MockOrderService.Verify(a => a.PopulateOrder(model, OrderData[1]), Times.Once);
+            MockDbContext.Verify(a => a.SaveChangesAsync(new CancellationToken()), Times.Once);
+        }
+
+        [Fact]
+        public async Task TestSaveWhenQuantityIs201ReturnsValidationJson()
+        {
+            // Arrange
+            var model = CreateValidOrderSaveModel(201);
+            ValidateModelIntoModelState(model);
+
+            // Act
+            var controllerResult = await Controller.Save(model);
+
+            // Assert
+            var result = Assert.IsType<JsonResult>(controllerResult);
+            dynamic data = JObject.FromObject(result.Value);
+            ((bool)data.success).ShouldBe(false);
+            ((string)data.message).ShouldBe("There were problems with your order. Unable to save. Errors: The field Quantity must be between 1 and 200.");
+
+            MockDbContext.Verify(a => a.SaveChangesAsync(new CancellationToken()), Times.Never);
+        }
+
+        [Fact]
+        public async Task TestSaveWhenCreateAndQuantityIs200Succeeds()
+        {
+            // Arrange
+            var model = CreateValidOrderSaveModel(200);
+            Order savedResult = null;
+            MockDbContext.Setup(a => a.Add(It.IsAny<Order>())).Callback<Order>(r => savedResult = r);
+            ValidateModelIntoModelState(model);
+
+            // Act
+            var controllerResult = await Controller.Save(model);
+
+            // Assert
+            var result = Assert.IsType<JsonResult>(controllerResult);
+            dynamic data = JObject.FromObject(result.Value);
+            ((bool)data.success).ShouldBe(true);
+            ((int)data.id).ShouldBe(0);
+
+            MockOrderService.Verify(a => a.PopulateOrder(model, It.IsAny<Order>()), Times.Once);
+            MockDbContext.Verify(a => a.Add(It.IsAny<Order>()), Times.Once);
+            MockDbContext.Verify(a => a.SaveChangesAsync(new CancellationToken()), Times.Once);
+            savedResult.ShouldNotBeNull();
         }
 
         [Fact]
@@ -1060,6 +1135,36 @@ namespace Test.TestsController
 
             MockLabworksService.Verify(a => a.GetClientDetails("Test"), Times.Once);
 
+        }
+
+        private static OrderSaveModel CreateValidOrderSaveModel(int quantity)
+        {
+            return new OrderSaveModel
+            {
+                Quantity = quantity,
+                SampleType = "Soil",
+                SelectedTests = new[] { new TestDetails { Id = "PH-S" } },
+                Project = "Project",
+                DateSampled = DateTime.Today,
+                SampleDisposition = "Dispose of my samples 30 days from report date."
+            };
+        }
+
+        private void ValidateModelIntoModelState(OrderSaveModel model)
+        {
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(
+                model,
+                new ValidationContext(model),
+                results,
+                validateAllProperties: true);
+
+            foreach (var result in results)
+            {
+                Controller.ModelState.AddModelError(
+                    result.MemberNames.FirstOrDefault() ?? string.Empty,
+                    result.ErrorMessage);
+            }
         }
     }
 

--- a/Test/TestsModel/OrderSaveModelTests.cs
+++ b/Test/TestsModel/OrderSaveModelTests.cs
@@ -1,0 +1,58 @@
+using Anlab.Core.Models;
+using AnlabMvc.Models.Order;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Xunit;
+
+namespace Test.TestsModel
+{
+    [Trait("Category", "ModelTests")]
+    public class OrderSaveModelTests
+    {
+        [Fact]
+        public void QuantityAllows200()
+        {
+            var results = Validate(CreateValidModel(200));
+
+            results.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void QuantityRejects201()
+        {
+            var results = Validate(CreateValidModel(201));
+
+            results.Count.ShouldBe(1);
+            results.Single().MemberNames.ShouldContain("Quantity");
+            results.Single().ErrorMessage.ShouldBe("The field Quantity must be between 1 and 200.");
+        }
+
+        private static IList<ValidationResult> Validate(OrderSaveModel model)
+        {
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(
+                model,
+                new ValidationContext(model),
+                results,
+                validateAllProperties: true);
+
+            return results;
+        }
+
+        private static OrderSaveModel CreateValidModel(int quantity)
+        {
+            return new OrderSaveModel
+            {
+                Quantity = quantity,
+                SampleType = "Soil",
+                SelectedTests = new[] { new TestDetails { Id = "PH-S" } },
+                Project = "Project",
+                DateSampled = DateTime.Today,
+                SampleDisposition = "Dispose of my samples 30 days from report date."
+            };
+        }
+    }
+}


### PR DESCRIPTION
Updates frontend UI messaging, client-side validation, backend model validation, and associated tests to reflect the new limit of 200 samples per work order.

Close Issue #1150 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maximum order quantity increased to 200; UI help text and inputs updated.

* **Bug Fixes**
  * Quantity validation and focus/handling corrected so ≤200 are accepted and >200 show proper errors.

* **UI/Text**
  * "Client Provided Id" field label wording updated.

* **Tests**
  * Added unit and UI tests validating the 200-limit behavior and related error messages.

* **Style**
  * Error text styling unified/updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Anlab/pull/1160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->