### PR TITLE
Adds TestGroup property to TestItem for categorization and filtering

### DIFF
--- a/Anlab.Core/Domain/TestItem.cs
+++ b/Anlab.Core/Domain/TestItem.cs
@@ -31,6 +31,15 @@ namespace Anlab.Core.Domain
             set => Category = string.Join("|", value);
         }
 
+        [StringLength(64)]
+        public string TestGroup { get; set; } = string.Empty;
+
+        public string[] TestGroups
+        {
+            get => TestGroup != null ? TestGroup.Split('|') : new string[0];
+            set => TestGroup = string.Join("|", value);
+        }
+
         [Required]
         [StringLength(512)]
         public string Group { get; set; }
@@ -68,5 +77,17 @@ namespace Anlab.Core.Domain
         public static string Miscellaneous = "Miscellaneous";
 
         public static readonly string[] All = { Soil, Plant, Water, Miscellaneous };
+    }
+
+    /// <summary>
+    /// Will be used to filter what tests a click can choose.
+    /// </summary>
+    public static class TestGroups
+    {
+        public static string AnLab = "AnLab";
+        public static string SIF = "SIF";
+        public static string ICPMS = "ICPMS";
+        public static string CDFA = "CDFA";
+        public static readonly string[] All = { AnLab, SIF, ICPMS, CDFA };
     }
 }

--- a/Anlab.Core/Domain/TestItem.cs
+++ b/Anlab.Core/Domain/TestItem.cs
@@ -34,6 +34,7 @@ namespace Anlab.Core.Domain
         [StringLength(64)]
         public string TestGroup { get; set; } = string.Empty;
 
+        [NotMapped]
         public string[] TestGroups
         {
             get => TestGroup != null ? TestGroup.Split('|') : new string[0];

--- a/Anlab.Mvc/Controllers/TestItemsController.cs
+++ b/Anlab.Mvc/Controllers/TestItemsController.cs
@@ -86,7 +86,7 @@ namespace AnlabMvc.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken] //Not really needed. Class inherits the Auto version, but it doesn't hurt
-        public async Task<IActionResult> Create([Bind("Id,Analysis,Categories,Group,Public,Notes,AdditonalInfoPrompt,LabOrder,RequestOrder,Reporting,DryMatter")] TestItem testItem)
+        public async Task<IActionResult> Create([Bind("Id,Analysis,Categories,TestGroups,Group,Public,Notes,AdditonalInfoPrompt,LabOrder,RequestOrder,Reporting,DryMatter")] TestItem testItem)
         {
             ModelState.Clear();
             TryValidateModel(testItem);
@@ -128,7 +128,7 @@ namespace AnlabMvc.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(string id, [Bind("Id, Categories, Analysis,Group,Public,Notes,AdditionalInfoPrompt,LabOrder,RequestOrder,Reporting,DryMatter")] TestItem testItem)
+        public async Task<IActionResult> Edit(string id, [Bind("Id, Categories, TestGroups, Analysis,Group,Public,Notes,AdditionalInfoPrompt,LabOrder,RequestOrder,Reporting,DryMatter")] TestItem testItem)
         {
             if (id != testItem.Id)
             {

--- a/Anlab.Mvc/Views/TestItems/Create.cshtml
+++ b/Anlab.Mvc/Views/TestItems/Create.cshtml
@@ -39,6 +39,10 @@
                 noneSelectedText: 'Select Categories',
                 selectedTextFormat: 'count > 4'
             });
+            $('#TestGroups').selectpicker({
+                noneSelectedText: 'Select Test Groups',
+                selectedTextFormat: 'count > 4'
+            });
         });
     </script>
 }

--- a/Anlab.Mvc/Views/TestItems/Edit.cshtml
+++ b/Anlab.Mvc/Views/TestItems/Edit.cshtml
@@ -40,6 +40,10 @@
                 noneSelectedText: 'Select Categories',
                 selectedTextFormat: 'count > 4'
             });
+            $('#TestGroups').selectpicker({
+                noneSelectedText: 'Select Test Groups',
+                selectedTextFormat: 'count > 4'
+            });
         });
     </script>
 }

--- a/Anlab.Mvc/Views/TestItems/Index.cshtml
+++ b/Anlab.Mvc/Views/TestItems/Index.cshtml
@@ -16,7 +16,7 @@
     </a>
 </p>
 }
-<div class="col">
+<div class="col test-items-index">
 <table id="table" class="row-border order-column hover">
     <thead>
         <tr>
@@ -42,6 +42,15 @@
                 }
                 </select>
 
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.TestGroup) <select name="testGroup" id="testGroup">
+                    <option value="All">All</option>
+                @foreach (var testGroup in TestGroups.All)
+                {
+                    <option value="@testGroup">@testGroup</option>
+                }
+                </select>
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.Group)
@@ -87,6 +96,9 @@
                 @item.Category.Humanize(LetterCasing.Title)
             </td>
             <td>
+                @(item.TestGroup?.Replace("|", " "))
+            </td>
+            <td>
                 @Html.DisplayFor(modelItem => item.Group)
             </td>
             <td style="text-align: center">
@@ -128,6 +140,12 @@
 @section AdditionalStyles
 {
     @{ await Html.RenderPartialAsync("_DataTableStylePartial"); }
+    <style>
+        .boundary:has(.test-items-index) {
+            width: 95%;
+            max-width: 1800px;
+        }
+    </style>
 }
 @section Scripts
 {
@@ -140,12 +158,15 @@
                 "stateSave": true,
                 "stateDuration": 60 * 10,
                 "columnDefs": [
-                    { "orderable": false, "targets": [0,5] },
+                    { "orderable": false, "targets": [0,5,6] },
                     { "searchable":false, "targets": 0 }
                 ]
             });
 
             $('#category').change(function () {
+                table.draw();
+            });
+            $('#testGroup').change(function () {
                 table.draw();
             });
         });
@@ -155,8 +176,11 @@
 
                 var category = data[5];
                 var categoryFilter = $('#category').val();
+                var testGroup = data[6];
+                var testGroupFilter = $('#testGroup').val();
 
-                if (categoryFilter == "All" || category.indexOf(categoryFilter) !== -1) {
+                if ((categoryFilter == "All" || category.indexOf(categoryFilter) !== -1) &&
+                    (testGroupFilter == "All" || testGroup.indexOf(testGroupFilter) !== -1)) {
                     return true;
                 }
                 return false;

--- a/Anlab.Mvc/Views/TestItems/_TestItemsDetails.cshtml
+++ b/Anlab.Mvc/Views/TestItems/_TestItemsDetails.cshtml
@@ -29,7 +29,13 @@
         @Html.DisplayNameFor(model => model.Category)
     </dt>
     <dd>
-        @Html.DisplayFor(model => model.Category)
+        @(Model.Category?.Replace("|", " "))
+    </dd>
+    <dt>
+        @Html.DisplayNameFor(model => model.TestGroup)
+    </dt>
+    <dd>
+        @(Model.TestGroup?.Replace("|", " "))
     </dd>
     <dt>
         @Html.DisplayNameFor(model => model.Group)

--- a/Anlab.Mvc/Views/TestItems/_TestItemsForm.cshtml
+++ b/Anlab.Mvc/Views/TestItems/_TestItemsForm.cshtml
@@ -2,6 +2,7 @@
 @model Anlab.Core.Domain.TestItem
 
 @Html.HiddenFor(a => a.Category)
+@Html.HiddenFor(a => a.TestGroup)
 <div class="col">
     <div class="form-group">
         <label asp-for="Analysis" class="col-md-2 control-label"></label>
@@ -20,6 +21,18 @@
                 }
             </select>
             <span asp-validation-for="Category" class="text-danger"></span>
+        </div>
+    </div>
+    <div class="form-group">
+        <label asp-for="TestGroup" class="col-md-2 control-label"></label>
+        <div class="col-md-3">
+            <select asp-for="TestGroups" class="form-control " multiple="multiple">
+                @foreach (var testGroup in TestGroups.All)
+                {
+                    <option value="@testGroup">@testGroup</option>
+                }
+            </select>
+            <span asp-validation-for="TestGroup" class="text-danger"></span>
         </div>
     </div>
     <div class="form-group">

--- a/Anlab.Sql/dbo/Tables/History.sql
+++ b/Anlab.Sql/dbo/Tables/History.sql
@@ -1,4 +1,4 @@
-CREATE TABLE [dbo].[History] (
+﻿CREATE TABLE [dbo].[History] (
     [Id]             INT            IDENTITY (1, 1) NOT NULL,
     [OrderId]        INT            NOT NULL,
     [ActionDateTime] DATETIME2 (7)  NOT NULL,
@@ -7,9 +7,7 @@ CREATE TABLE [dbo].[History] (
     [ActorName]      NVARCHAR (250) NULL,
     [Notes]          NVARCHAR (MAX) NULL,
     [JsonDetails]    NVARCHAR (MAX) NULL,
-    [Status] NVARCHAR(50) NULL, 
-    CONSTRAINT [PK_History] PRIMARY KEY CLUSTERED ([Id] ASC), 
-    CONSTRAINT [FK_History_Orders] FOREIGN KEY ([OrderId]) REFERENCES [dbo].[Orders]([Id])
+    [Status]         NVARCHAR (50)  NULL,
+    CONSTRAINT [PK_History] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
-
 

--- a/Anlab.Sql/dbo/Tables/MailMessages.sql
+++ b/Anlab.Sql/dbo/Tables/MailMessages.sql
@@ -1,4 +1,4 @@
-CREATE TABLE [dbo].[MailMessages] (
+﻿CREATE TABLE [dbo].[MailMessages] (
     [Id]            INT            IDENTITY (1, 1) NOT NULL,
     [Body]          NVARCHAR (MAX) NOT NULL,
     [CreatedAt]     DATETIME2 (7)  NOT NULL,
@@ -9,11 +9,12 @@ CREATE TABLE [dbo].[MailMessages] (
     [SentAt]        DATETIME2 (7)  NULL,
     [Subject]       NVARCHAR (256) NOT NULL,
     [UserId]        NVARCHAR (450) NULL,
-    [FailureCount] INT NOT NULL DEFAULT 0, 
+    [FailureCount]  INT            DEFAULT ((0)) NOT NULL,
     CONSTRAINT [PK_MailMessages] PRIMARY KEY CLUSTERED ([Id] ASC),
-    CONSTRAINT [FK_MailMessages_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [dbo].[AspNetUsers] ([Id]),
-    CONSTRAINT [FK_MailMessages_Orders_OrderId] FOREIGN KEY ([OrderId]) REFERENCES [dbo].[Orders] ([Id])
+    CONSTRAINT [FK_MailMessages_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [dbo].[AspNetUsers] ([Id])
 );
+
+
 
 
 GO

--- a/Anlab.Sql/dbo/Tables/Orders.sql
+++ b/Anlab.Sql/dbo/Tables/Orders.sql
@@ -1,4 +1,4 @@
-CREATE TABLE [dbo].[Orders] (
+﻿CREATE TABLE [dbo].[Orders] (
     [Id]                            INT              IDENTITY (1, 1) NOT NULL,
     [AdditionalEmails]              NVARCHAR (MAX)   NULL,
     [ApprovedPaymentTransaction_Id] NVARCHAR (450)   NULL,
@@ -6,28 +6,28 @@ CREATE TABLE [dbo].[Orders] (
     [Created]                       DATETIME2 (7)    NOT NULL,
     [CreatorId]                     NVARCHAR (450)   NOT NULL,
     [JsonDetails]                   NVARCHAR (MAX)   NULL,
-    [KfsTrackingNumber]             NVARCHAR (20)   NULL,
+    [KfsTrackingNumber]             NVARCHAR (20)    NULL,
     [LabId]                         NVARCHAR (16)    NULL,
     [Paid]                          BIT              NOT NULL,
-    [PaymentType]                   NVARCHAR (50)   NULL,
+    [PaymentType]                   NVARCHAR (50)    NULL,
     [Project]                       NVARCHAR (256)   NOT NULL,
-    [RequestNum]                    NVARCHAR (50)   NULL,
+    [RequestNum]                    NVARCHAR (50)    NULL,
     [ResultsFileIdentifier]         NVARCHAR (MAX)   NULL,
     [SavedTestDetails]              NVARCHAR (MAX)   NULL,
     [ShareIdentifier]               UNIQUEIDENTIFIER NOT NULL,
-    [SignedEnvelopeId]              NVARCHAR (50)   NULL,
-    [SlothTransactionId]            UNIQUEIDENTIFIER   NULL,
-    [Status]                        NVARCHAR (50)   NULL,
+    [SlothTransactionId]            UNIQUEIDENTIFIER NULL,
+    [Status]                        NVARCHAR (50)    NULL,
     [Updated]                       DATETIME2 (7)    NOT NULL,
-    [IsDeleted] BIT NOT NULL DEFAULT ((0)),
-    [ClientName] VARCHAR(512) NULL,
-    [BackedupTestDetails] NVARCHAR(MAX) NULL,
-    [DateFinalized] DATETIME2 NULL,
-    [SkippedFinalEmail] BIT NOT NULL DEFAULT ((0)), 
-    CONSTRAINT [PK_Orders] PRIMARY KEY CLUSTERED ([Id] ASC),
-    CONSTRAINT [FK_Orders_AspNetUsers_CreatorId] FOREIGN KEY ([CreatorId]) REFERENCES [dbo].[AspNetUsers] ([Id]) ON DELETE CASCADE,
-    CONSTRAINT [FK_Orders_PaymentEvents_ApprovedPaymentTransaction_Id] FOREIGN KEY ([ApprovedPaymentTransaction_Id]) REFERENCES [dbo].[PaymentEvents] ([Transaction_Id])
+    [IsDeleted]                     BIT              NOT NULL,
+    [ClientName]                    VARCHAR (512)    NULL,
+    [BackedupTestDetails]           NVARCHAR (MAX)   NULL,
+    [DateFinalized]                 DATETIME2 (7)    NULL,
+    [SignedEnvelopeId]              NVARCHAR (50)    NULL,
+    [SkippedFinalEmail]             BIT              CONSTRAINT [DF_Orders_SkippedFinalEmail] DEFAULT ((0)) NOT NULL,
+    CONSTRAINT [PK_Orders] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
+
+
 
 
 GO

--- a/Anlab.Sql/dbo/Tables/TestItems.sql
+++ b/Anlab.Sql/dbo/Tables/TestItems.sql
@@ -1,4 +1,4 @@
-﻿CREATE TABLE [dbo].[TestItems] (
+CREATE TABLE [dbo].[TestItems] (
     [Id]                   NVARCHAR (128) NOT NULL,
     [AdditionalInfoPrompt] NVARCHAR (MAX) NULL,
     [Analysis]             NVARCHAR (512) NOT NULL,
@@ -10,6 +10,7 @@
     [RequestOrder]         INT            NOT NULL,
     [Reporting]            BIT            DEFAULT ((0)) NOT NULL,
     [DryMatter]            BIT            CONSTRAINT [DF_TestItems_DryMatter] DEFAULT ((0)) NOT NULL,
+    [TestGroup]            NVARCHAR(64)   DEFAULT('') NOT NULL,
     CONSTRAINT [PK_TestItems] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
 

--- a/Anlab.Sql/dbo/Tables/TestItems.sql
+++ b/Anlab.Sql/dbo/Tables/TestItems.sql
@@ -1,4 +1,4 @@
-CREATE TABLE [dbo].[TestItems] (
+﻿CREATE TABLE [dbo].[TestItems] (
     [Id]                   NVARCHAR (128) NOT NULL,
     [AdditionalInfoPrompt] NVARCHAR (MAX) NULL,
     [Analysis]             NVARCHAR (512) NOT NULL,
@@ -8,11 +8,8 @@ CREATE TABLE [dbo].[TestItems] (
     [Notes]                NVARCHAR (MAX) NULL,
     [Public]               BIT            NOT NULL,
     [RequestOrder]         INT            NOT NULL,
-    [Reporting] BIT NOT NULL DEFAULT 0, 
-    [DryMatter] BIT NOT NULL DEFAULT 0, 
-    [TestGroup] NVARCHAR(64) NOT NULL, 
+    [Reporting]            BIT            DEFAULT ((0)) NOT NULL,
+    [DryMatter]            BIT            CONSTRAINT [DF_TestItems_DryMatter] DEFAULT ((0)) NOT NULL,
     CONSTRAINT [PK_TestItems] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
-
-
 

--- a/Anlab.Sql/dbo/Tables/TestItems.sql
+++ b/Anlab.Sql/dbo/Tables/TestItems.sql
@@ -10,6 +10,7 @@ CREATE TABLE [dbo].[TestItems] (
     [RequestOrder]         INT            NOT NULL,
     [Reporting] BIT NOT NULL DEFAULT 0, 
     [DryMatter] BIT NOT NULL DEFAULT 0, 
+    [TestGroup] NVARCHAR(64) NOT NULL, 
     CONSTRAINT [PK_TestItems] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
 

--- a/Anlab.Sql/dbo/Views/HistoricalSalesView.sql
+++ b/Anlab.Sql/dbo/Views/HistoricalSalesView.sql
@@ -5,3 +5,116 @@ SELECT Id, DateFinalized, JSON_QUERY(JsonDetails, '$.SelectedTests') AS Selected
 FROM   dbo.Orders
 WHERE (DateFinalized IS NOT NULL)
 GO
+EXECUTE sp_addextendedproperty @name = N'MS_DiagramPaneCount', @value = 1, @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'VIEW', @level1name = N'HistoricalSalesView';
+
+
+GO
+EXECUTE sp_addextendedproperty @name = N'MS_DiagramPane1', @value = N'[0E232FF0-B466-11cf-A24F-00AA00A3EFFF, 1.00]
+Begin DesignProperties = 
+   Begin PaneConfigurations = 
+      Begin PaneConfiguration = 0
+         NumPanes = 4
+         Configuration = "(H (1[40] 4[20] 2[20] 3) )"
+      End
+      Begin PaneConfiguration = 1
+         NumPanes = 3
+         Configuration = "(H (1 [50] 4 [25] 3))"
+      End
+      Begin PaneConfiguration = 2
+         NumPanes = 3
+         Configuration = "(H (1 [50] 2 [25] 3))"
+      End
+      Begin PaneConfiguration = 3
+         NumPanes = 3
+         Configuration = "(H (4 [30] 2 [40] 3))"
+      End
+      Begin PaneConfiguration = 4
+         NumPanes = 2
+         Configuration = "(H (1 [56] 3))"
+      End
+      Begin PaneConfiguration = 5
+         NumPanes = 2
+         Configuration = "(H (2 [66] 3))"
+      End
+      Begin PaneConfiguration = 6
+         NumPanes = 2
+         Configuration = "(H (4 [50] 3))"
+      End
+      Begin PaneConfiguration = 7
+         NumPanes = 1
+         Configuration = "(V (3))"
+      End
+      Begin PaneConfiguration = 8
+         NumPanes = 3
+         Configuration = "(H (1[56] 4[18] 2) )"
+      End
+      Begin PaneConfiguration = 9
+         NumPanes = 2
+         Configuration = "(H (1 [75] 4))"
+      End
+      Begin PaneConfiguration = 10
+         NumPanes = 2
+         Configuration = "(H (1[66] 2) )"
+      End
+      Begin PaneConfiguration = 11
+         NumPanes = 2
+         Configuration = "(H (4 [60] 2))"
+      End
+      Begin PaneConfiguration = 12
+         NumPanes = 1
+         Configuration = "(H (1) )"
+      End
+      Begin PaneConfiguration = 13
+         NumPanes = 1
+         Configuration = "(V (4))"
+      End
+      Begin PaneConfiguration = 14
+         NumPanes = 1
+         Configuration = "(V (2))"
+      End
+      ActivePaneConfig = 0
+   End
+   Begin DiagramPane = 
+      Begin Origin = 
+         Top = 0
+         Left = 0
+      End
+      Begin Tables = 
+         Begin Table = "Orders (dbo)"
+            Begin Extent = 
+               Top = 10
+               Left = 67
+               Bottom = 240
+               Right = 482
+            End
+            DisplayFlags = 280
+            TopColumn = 0
+         End
+      End
+   End
+   Begin SQLPane = 
+   End
+   Begin DataPane = 
+      Begin ParameterDefaults = ""
+      End
+   End
+   Begin CriteriaPane = 
+      Begin ColumnWidths = 11
+         Column = 1440
+         Alias = 900
+         Table = 1174
+         Output = 720
+         Append = 1400
+         NewValue = 1170
+         SortType = 1354
+         SortOrder = 1414
+         GroupBy = 1350
+         Filter = 1354
+         Or = 1350
+         Or = 1350
+         Or = 1350
+      End
+   End
+End
+', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'VIEW', @level1name = N'HistoricalSalesView';
+

--- a/Test/TestsDatabase/TestItemTests.cs
+++ b/Test/TestsDatabase/TestItemTests.cs
@@ -56,6 +56,14 @@ namespace Test.TestsDatabase
             expectedFields.Add(new NameAndType("Public", "System.Boolean", new List<string>()));
             expectedFields.Add(new NameAndType("Reporting", "System.Boolean", new List<string>()));
             expectedFields.Add(new NameAndType("RequestOrder", "System.Int32", new List<string>()));
+            expectedFields.Add(new NameAndType("TestGroup", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)64)]"
+            }));
+            expectedFields.Add(new NameAndType("TestGroups", "System.String[]", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.Schema.NotMappedAttribute()]"
+            }));
             #endregion Arrange
 
             AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(TestItem));

--- a/Test/TestsModel/TestItemModelTest.cs
+++ b/Test/TestsModel/TestItemModelTest.cs
@@ -48,6 +48,14 @@ namespace Test.TestsModel
             expectedFields.Add(new NameAndType("Public", "System.Boolean", new List<string>()));
             expectedFields.Add(new NameAndType("Reporting", "System.Boolean", new List<string>()));
             expectedFields.Add(new NameAndType("RequestOrder", "System.Int32", new List<string>()));
+            expectedFields.Add(new NameAndType("TestGroup", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)64)]"
+            }));
+            expectedFields.Add(new NameAndType("TestGroups", "System.String[]", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.Schema.NotMappedAttribute()]"
+            }));
             #endregion Arrange
 
             AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(TestItem));


### PR DESCRIPTION
This introduces a new TestGroup field in the TestItem domain object and database column. It allows test items to be associated with predefined groups (e.g., AnLab, SIF) and facilitates filtering available tests for clients. issue #1161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test items can now be organized into one or more groups for improved categorization and management.
  * Four test group categories are available for classification: AnLab, SIF, ICPMS, CDFA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->