### PR TITLE
Add optional AnLab project code and client provided ID fields

### DIFF
--- a/Anlab.Core/Models/OrderDetails.cs
+++ b/Anlab.Core/Models/OrderDetails.cs
@@ -22,7 +22,11 @@ namespace Anlab.Core.Models
         public string[] AdditionalEmails { get; set; }
 
         public string Project { get; set; }
+        [StringLength(20)]
+        public string ProjectCode { get; set; }
         public string Commodity { get; set; }
+        [StringLength(6)]
+        public string ClientProvidedId { get; set; }
         public DateTime DateSampled { get; set; }
 
         public string SampleDisposition { get; set; }

--- a/Anlab.Core/Models/OrderDetails.cs
+++ b/Anlab.Core/Models/OrderDetails.cs
@@ -22,7 +22,7 @@ namespace Anlab.Core.Models
         public string[] AdditionalEmails { get; set; }
 
         public string Project { get; set; }
-        [StringLength(20)]
+        [StringLength(30)]
         public string ProjectCode { get; set; }
         public string Commodity { get; set; }
         [StringLength(6)]

--- a/Anlab.Mvc/ClientApp/src/components/OrderForm.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/OrderForm.tsx
@@ -398,7 +398,7 @@ export default class OrderForm extends React.Component<
                     <Input
                       label="AnLab Project Code (provided by Lab if applicable)"
                       value={projectCode}
-                      maxLength={20}
+                      maxLength={30}
                       onChange={(e) =>
                         this._handleChange("projectCode", e.target.value)
                       }

--- a/Anlab.Mvc/ClientApp/src/components/OrderForm.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/OrderForm.tsx
@@ -25,6 +25,7 @@ import Summary from "./Summary";
 import { ITestItem, TestList } from "./TestList";
 import { ViewMode } from "./ViewMode";
 import { SamplePlantQuestionsOptions } from "./SamplePlantQuestions";
+import Input from "./ui/input/input";
 
 declare var $: any;
 
@@ -52,8 +53,10 @@ interface IOrderFormState {
   placingOrder: boolean;
   additionalInfo: string;
   project: string;
+  projectCode: string;
   filteredTests: ITestItem[];
   commodity: string;
+  clientProvidedId: string;
   dateSampled: any;
   sampleDisposition: string;
   payment: IPayment;
@@ -140,6 +143,7 @@ export default class OrderForm extends React.Component<
       },
       placingOrder: this.props.defaultPlacingOrder,
       project: "",
+      projectCode: "",
       quantity: null,
       sampleDisposition: "",
       sampleType: "",
@@ -160,6 +164,7 @@ export default class OrderForm extends React.Component<
       selectedCodes: {},
       selectedTests: [],
       status: "",
+      clientProvidedId: "",
     };
 
     if (this.props.defaultAccount) {
@@ -195,7 +200,9 @@ export default class OrderForm extends React.Component<
       };
       initialState.sampleDisposition = orderInfo.SampleDisposition;
       initialState.project = orderInfo.Project;
+      initialState.projectCode = orderInfo.ProjectCode || "";
       initialState.commodity = orderInfo.Commodity;
+      initialState.clientProvidedId = orderInfo.ClientProvidedId || "";
       initialState.dateSampled = moment(orderInfo.DateSampled);
       initialState.isValid = true;
       initialState.payment.clientType = orderInfo.Payment.ClientType;
@@ -264,7 +271,9 @@ export default class OrderForm extends React.Component<
       quantity,
       additionalInfo,
       project,
+      projectCode,
       commodity,
+      clientProvidedId,
       dateSampled,
       sampleDisposition,
       additionalEmails,
@@ -364,20 +373,46 @@ export default class OrderForm extends React.Component<
                 <label className="form_header">
                   What is the project title associated with this order?
                 </label>
-                <Project
-                  project={project}
-                  handleChange={this._handleChange}
-                  projectRef={(inputRef) => {
-                    this.projectRef = inputRef;
-                  }}
-                />
-                <Commodity
-                  commodity={commodity}
-                  handleChange={this._handleChange}
-                  commodityRef={(inputRef) => {
-                    this.commodityRef = inputRef;
-                  }}
-                />
+                <p className="help-block">
+                  Project Title / Location can be used to help organize your
+                  submissions
+                </p>
+                <div className="flexrow">
+                  <div className="flexcol">
+                    <Project
+                      project={project}
+                      handleChange={this._handleChange}
+                      projectRef={(inputRef) => {
+                        this.projectRef = inputRef;
+                      }}
+                    />
+                    <Commodity
+                      commodity={commodity}
+                      handleChange={this._handleChange}
+                      commodityRef={(inputRef) => {
+                        this.commodityRef = inputRef;
+                      }}
+                    />
+                  </div>
+                  <div className="flexcol">
+                    <Input
+                      label="AnLab Project Code (provided by Lab if applicable)"
+                      value={projectCode}
+                      maxLength={20}
+                      onChange={(e) =>
+                        this._handleChange("projectCode", e.target.value)
+                      }
+                    />
+                    <Input
+                      label="Client Provided Id"
+                      value={clientProvidedId}
+                      maxLength={6}
+                      onChange={(e) =>
+                        this._handleChange("clientProvidedId", e.target.value)
+                      }
+                    />
+                  </div>
+                </div>
               </div>
             </div>
           </Collapse>
@@ -1101,10 +1136,12 @@ export default class OrderForm extends React.Component<
       clientInfo: {
         ...this.state.clientInfo,
       },
+      clientProvidedId: this.state.clientProvidedId,
       orderId: this.props.orderId,
       otherPaymentInfo: this.state.otherPaymentInfo,
       payment: this.state.payment,
       project: this.state.project,
+      projectCode: this.state.projectCode,
       quantity: this.state.quantity,
       sampleDisposition: this.state.sampleDisposition,
       sampleType: this.state.sampleType,

--- a/Anlab.Mvc/ClientApp/src/components/Project.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/Project.tsx
@@ -25,20 +25,15 @@ export class Project extends React.Component<
 
   public render() {
     return (
-      <div>
-        <p className="help-block">
-          Project Title / Location can be used to help organize your submissions
-        </p>
-        <Input
-          label="Project Title / Location"
-          value={this.props.project}
-          error={this.state.error}
-          required={true}
-          maxLength={256}
-          onChange={this._onChange}
-          inputRef={this.props.projectRef}
-        />
-      </div>
+      <Input
+        label="Project Title / Location"
+        value={this.props.project}
+        error={this.state.error}
+        required={true}
+        maxLength={256}
+        onChange={this._onChange}
+        inputRef={this.props.projectRef}
+      />
     );
   }
 

--- a/Anlab.Mvc/Models/Order/OrderSaveModel.cs
+++ b/Anlab.Mvc/Models/Order/OrderSaveModel.cs
@@ -33,7 +33,7 @@ namespace AnlabMvc.Models.Order
         [StringLength(256)]
         public string Project { get; set; }
 
-        [StringLength(20)]
+        [StringLength(30)]
         public string ProjectCode { get; set; }
 
         public string Commodity { get; set; }

--- a/Anlab.Mvc/Models/Order/OrderSaveModel.cs
+++ b/Anlab.Mvc/Models/Order/OrderSaveModel.cs
@@ -32,7 +32,14 @@ namespace AnlabMvc.Models.Order
         [Required]
         [StringLength(256)]
         public string Project { get; set; }
+
+        [StringLength(20)]
+        public string ProjectCode { get; set; }
+
         public string Commodity { get; set; }
+
+        [StringLength(6)]
+        public string ClientProvidedId { get; set; }
 
         [Required]
         public DateTime DateSampled { get; set; }

--- a/Anlab.Mvc/Views/Order/Confirmed.cshtml
+++ b/Anlab.Mvc/Views/Order/Confirmed.cshtml
@@ -239,6 +239,20 @@
                     <span>@Model.OrderDetails.Commodity</span>
                 </div>
             }
+            @if (!string.IsNullOrWhiteSpace(Model.OrderDetails.ProjectCode))
+            {
+                <div class="form-group">
+                    <strong>AnLab Project Code:</strong>
+                    <span>@Model.OrderDetails.ProjectCode</span>
+                </div>
+            }
+            @if (!string.IsNullOrWhiteSpace(Model.OrderDetails.ClientProvidedId))
+            {
+                <div class="form-group">
+                    <strong>Client Provided Id:</strong>
+                    <span>@Model.OrderDetails.ClientProvidedId</span>
+                </div>
+            }
             <div class="form-group">
                 <strong>Date Sampled:</strong>
                 <span>@Model.OrderDetails.DateSampled.ToLongDateString()</span>

--- a/Anlab.Mvc/Views/Order/Document.cshtml
+++ b/Anlab.Mvc/Views/Order/Document.cshtml
@@ -192,6 +192,18 @@
                         <strong>Commodity:</strong>
                         <span>@Model.OrderDetails.Commodity</span>
                     }
+            </p><p>
+                    @if (!string.IsNullOrWhiteSpace(Model.OrderDetails.ProjectCode))
+                    {
+                        <strong>AnLab Project Code:</strong>
+                        <span>@Model.OrderDetails.ProjectCode</span>
+                    }
+            </p><p>
+                    @if (!string.IsNullOrWhiteSpace(Model.OrderDetails.ClientProvidedId))
+                    {
+                        <strong>Client Provided Id:</strong>
+                        <span>@Model.OrderDetails.ClientProvidedId</span>
+                    }
             </p>
             <p>
             <strong>Date Sampled:</strong>

--- a/Anlab.Mvc/Views/Shared/_OrderDetails.cshtml
+++ b/Anlab.Mvc/Views/Shared/_OrderDetails.cshtml
@@ -124,6 +124,20 @@
     </div>
 
 }
+@if (!string.IsNullOrWhiteSpace(Model.OrderDetails.ProjectCode))
+{
+    <div class="form-group">
+        <strong>AnLab Project Code</strong>
+        <span>@Model.OrderDetails.ProjectCode</span>
+    </div>
+}
+@if (!string.IsNullOrWhiteSpace(Model.OrderDetails.ClientProvidedId))
+{
+    <div class="form-group">
+        <strong>Client Provided Id</strong>
+        <span>@Model.OrderDetails.ClientProvidedId</span>
+    </div>
+}
 
 <div class="form-group">
     <strong>Date Sampled</strong>

--- a/Test/TestsModel/CoreModelTests.cs
+++ b/Test/TestsModel/CoreModelTests.cs
@@ -166,7 +166,7 @@ namespace Test.TestsModel
             expectedFields.Add(new NameAndType("Project", "System.String", new List<string>()));
             expectedFields.Add(new NameAndType("ProjectCode", "System.String", new List<string>
             {
-                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)20)]"
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)30)]"
             }));
             expectedFields.Add(new NameAndType("Quantity", "System.Int32", new List<string>()));
             expectedFields.Add(new NameAndType("RushMultiplier", "System.Nullable`1[System.Decimal]", new List<string>()));

--- a/Test/TestsModel/CoreModelTests.cs
+++ b/Test/TestsModel/CoreModelTests.cs
@@ -147,6 +147,10 @@ namespace Test.TestsModel
             expectedFields.Add(new NameAndType("AdjustmentAmount", "System.Decimal", new List<string>()));
             expectedFields.Add(new NameAndType("AdjustmentComments", "System.String", new List<string>()));
             expectedFields.Add(new NameAndType("ClientInfo", "Anlab.Core.Models.ClientInfo", new List<string>()));
+            expectedFields.Add(new NameAndType("ClientProvidedId", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)6)]"
+            }));
             expectedFields.Add(new NameAndType("Commodity", "System.String", new List<string>()));
             expectedFields.Add(new NameAndType("DateSampled", "System.DateTime", new List<string>()));
             expectedFields.Add(new NameAndType("ExternalProcessingFee", "System.Decimal", new List<string>()));
@@ -160,6 +164,10 @@ namespace Test.TestsModel
             expectedFields.Add(new NameAndType("OtherPaymentInfo", "Anlab.Core.Models.OtherPaymentInfo", new List<string>()));
             expectedFields.Add(new NameAndType("Payment", "Anlab.Core.Models.Payment", new List<string>()));
             expectedFields.Add(new NameAndType("Project", "System.String", new List<string>()));
+            expectedFields.Add(new NameAndType("ProjectCode", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)20)]"
+            }));
             expectedFields.Add(new NameAndType("Quantity", "System.Int32", new List<string>()));
             expectedFields.Add(new NameAndType("RushMultiplier", "System.Nullable`1[System.Decimal]", new List<string>()));
             expectedFields.Add(new NameAndType("SampleDisposition", "System.String", new List<string>()));


### PR DESCRIPTION
Introduces new optional fields for 'AnLab Project Code' and 'Client Provided Id' on the order submission form. These fields are integrated into the order details model, user interface, and various display views (confirmation, document, and shared details) to provide additional identifiers for orders.

Issue #1154 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now provide an AnLab Project Code (up to 30 chars) and Client Provided ID (up to 6 chars) when submitting orders; both are optional and appear on order confirmations and documents.
* **Tests**
  * Model validation tests updated to include the new fields and their length constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Anlab/pull/1164)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->