### PR TITLE
Remove outdated PO agreement processing alert

### DIFF
--- a/Anlab.Mvc/ClientApp/src/components/PaymentSelection.tsx
+++ b/Anlab.Mvc/ClientApp/src/components/PaymentSelection.tsx
@@ -223,11 +223,6 @@ export class PaymentSelection extends React.Component<
               with placing your order and you will be contacted by our lab. You
               may unclick the box to stop the agreement process.{" "}
             </div>
-            <div className="alert alert-danger" role="alert">
-              PLEASE NOTE: Due to the University updating its Financial System,
-              PO Agreements will not be processed from 11/01/23 through
-              01/03/24.
-            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated alert notice from the payment selection flow regarding PO Agreements processing restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->