### PR TITLE
Strip Html for text alternative emails

### DIFF
--- a/Anlab.Core/Services/HtmlEmailTextFormatter.cs
+++ b/Anlab.Core/Services/HtmlEmailTextFormatter.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace Anlab.Core.Services
+{
+    public static class HtmlEmailTextFormatter
+    {
+        private const RegexOptions HtmlRegexOptions = RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.CultureInvariant;
+
+        public static string ToPlainText(string html)
+        {
+            if (string.IsNullOrWhiteSpace(html))
+            {
+                return string.Empty;
+            }
+
+            var text = html;
+            text = Regex.Replace(text, @"<!--.*?-->", string.Empty, HtmlRegexOptions);
+            text = Regex.Replace(text, @"<\s*(head|style|script)[^>]*>.*?<\s*/\s*\1\s*>", string.Empty, HtmlRegexOptions);
+            text = Regex.Replace(text, @"<\s*br\s*/?\s*>", "\n", HtmlRegexOptions);
+            text = Regex.Replace(text, @"<\s*/\s*(p|div|section|article|header|footer|h[1-6]|li|tr|table|mj-section|mj-column)\s*>", "\n", HtmlRegexOptions);
+            text = Regex.Replace(text, @"<\s*(p|div|section|article|header|footer|h[1-6]|li|tr|table|mj-section|mj-column)[^>]*>", "\n", HtmlRegexOptions);
+            text = Regex.Replace(text, @"<\s*/\s*(td|th)\s*>", "  ", HtmlRegexOptions);
+            text = Regex.Replace(text, @"<\s*(td|th)[^>]*>", string.Empty, HtmlRegexOptions);
+            text = Regex.Replace(text, @"<\s*a\b[^>]*href\s*=\s*(?:""(?<href>[^""]*)""|'(?<href>[^']*)'|(?<href>[^\s>]+))[^>]*>(?<text>.*?)<\s*/\s*a\s*>", FormatLink, HtmlRegexOptions);
+            text = Regex.Replace(text, @"<[^>]+>", string.Empty, HtmlRegexOptions);
+            text = WebUtility.HtmlDecode(text);
+            text = text.Replace('\u00A0', ' ');
+            text = text.Replace("\r\n", "\n").Replace('\r', '\n');
+            text = Regex.Replace(text, @"[ \t\f\v]+", " ");
+            text = Regex.Replace(text, @" *\n *", "\n");
+            text = Regex.Replace(text, @"\n{3,}", "\n\n");
+
+            return text.Trim();
+        }
+
+        private static string FormatLink(Match match)
+        {
+            var linkText = ToPlainText(match.Groups["text"].Value);
+            var href = WebUtility.HtmlDecode(match.Groups["href"].Value ?? string.Empty).Trim();
+
+            if (string.IsNullOrWhiteSpace(linkText))
+            {
+                return href;
+            }
+
+            if (string.IsNullOrWhiteSpace(href) || string.Equals(linkText, href, StringComparison.OrdinalIgnoreCase))
+            {
+                return linkText;
+            }
+
+            return $"{linkText}: {href}";
+        }
+    }
+}

--- a/Anlab.Core/Services/MailService.cs
+++ b/Anlab.Core/Services/MailService.cs
@@ -74,7 +74,7 @@ namespace Anlab.Core.Services
 
             message.Subject = mailMessage.Subject;
             message.IsBodyHtml = false;
-            message.Body = mailMessage.Body;
+            message.Body = HtmlEmailTextFormatter.ToPlainText(mailMessage.Body);
             var mimeType = new System.Net.Mime.ContentType("text/html");
             var alternate = AlternateView.CreateAlternateViewFromString(mailMessage.Body, mimeType);
             message.AlternateViews.Add(alternate);
@@ -105,7 +105,7 @@ namespace Anlab.Core.Services
 
                 message.Subject = $"T.O.P.S. Email Failure. Order Id {orderId}";
                 message.IsBodyHtml = false;
-                message.Body = body;
+                message.Body = HtmlEmailTextFormatter.ToPlainText(body);
                 var mimeType = new System.Net.Mime.ContentType("text/html");
                 var alternate = AlternateView.CreateAlternateViewFromString(body, mimeType);
                 message.AlternateViews.Add(alternate);

--- a/Test/TestsServices/HtmlEmailTextFormatterTests.cs
+++ b/Test/TestsServices/HtmlEmailTextFormatterTests.cs
@@ -1,0 +1,64 @@
+using Anlab.Core.Services;
+using Shouldly;
+using Xunit;
+
+namespace Test.TestsServices
+{
+    public class HtmlEmailTextFormatterTests
+    {
+        [Fact]
+        public void ToPlainText_RemovesHtmlChromeAndPreservesReadableContent()
+        {
+            var plainText = HtmlEmailTextFormatter.ToPlainText(
+                @"<html>
+                    <head>
+                        <style>.button { color: red; }</style>
+                        <title>Anlab</title>
+                    </head>
+                    <body>
+                        <h1>Work Request 22F107</h1>
+                        <p>Hello&nbsp;<strong>Client</strong>,</p>
+                        <p>Your work order has been completed.</p>
+                    </body>
+                </html>");
+
+            plainText.ShouldBe(
+                @"Work Request 22F107
+
+Hello Client,
+
+Your work order has been completed.");
+            plainText.ShouldNotContain("<");
+            plainText.ShouldNotContain("button");
+            plainText.ShouldNotContain("Anlab");
+        }
+
+        [Fact]
+        public void ToPlainText_FormatsLinksWithTheirUrl()
+        {
+            var plainText = HtmlEmailTextFormatter.ToPlainText(
+                @"<p>Results are ready.</p>
+                  <p><a href=""https://localhost:5001/Results/Link/11111111-1111-1111-1111-111111111111"">Get Your Results</a></p>");
+
+            plainText.ShouldBe(
+                @"Results are ready.
+
+Get Your Results: https://localhost:5001/Results/Link/11111111-1111-1111-1111-111111111111");
+        }
+
+        [Fact]
+        public void ToPlainText_AddsSpacingBetweenTableCells()
+        {
+            var plainText = HtmlEmailTextFormatter.ToPlainText(
+                @"<table>
+                    <tr><th>Online Order Number</th><td>2920</td></tr>
+                    <tr><th>Payment Method</th><td>IOC</td></tr>
+                  </table>");
+
+            plainText.ShouldBe(
+                @"Online Order Number 2920
+
+Payment Method IOC");
+        }
+    }
+}


### PR DESCRIPTION
Generate plain-text body for HTML emails

Emails now include a structured plain-text version derived from the HTML content. This improves compatibility and readability for email clients that do not render HTML or prefer a text-only view, ensuring a coherent message is always presented.
```