### PR TITLE
Add sample amount guide and acknowledgment to DocuSign

### DIFF
--- a/Anlab.Mvc/Services/DocumentSigningService.cs
+++ b/Anlab.Mvc/Services/DocumentSigningService.cs
@@ -34,6 +34,10 @@ public class DocumentSigningService : IDocumentSigningService
     private readonly ESignatureOptions _eSignatureSettings;
 
     private static readonly string SignerClientId = "1000";
+    private const string SampleAmountGuideText = "Sample Amount Guide";
+    private const string SampleAmountGuideAnchor = "**sample_amount_guide_link**";
+    private const string SampleAmountGuideUrl = "https://anlab.ucdavis.edu/forms-and-guides";
+    private const string SampleAmountGuideTabLabel = "#HREF_SampleAmountGuide";
 
     public DocumentSigningService(IOptions<ESignatureOptions> eSignatureSettings, ApplicationDbContext dbContext, IHttpContextAccessor httpContextAccessor)
     {
@@ -247,8 +251,27 @@ public class DocumentSigningService : IDocumentSigningService
             AnchorXOffset = "20",
         };
 
+        var sampleAmountGuideLink = new Text
+        {
+            AnchorString = SampleAmountGuideAnchor,
+            AnchorUnits = "pixels",
+            TabLabel = SampleAmountGuideTabLabel,
+            Value = SampleAmountGuideText,
+            Name = SampleAmountGuideUrl,
+            Tooltip = SampleAmountGuideUrl,
+            Required = "true",
+            Locked = "true",
+            FontColor = "BrightBlue",
+            Underline = "true",
+        };
+
         // add sign here & date signed tabs for signer
-        signer.Tabs = new Tabs {SignHereTabs = new List<SignHere> {signHere}, DateSignedTabs = new List<DateSigned> {dateSigned }};
+        signer.Tabs = new Tabs
+        {
+            SignHereTabs = new List<SignHere> {signHere},
+            DateSignedTabs = new List<DateSigned> {dateSigned},
+            TextTabs = new List<Text> {sampleAmountGuideLink}
+        };
 
         // add signer to envelope
         env.Recipients = new Recipients {Signers = new List<Signer> {signer}};

--- a/Anlab.Mvc/Views/Order/Document.cshtml
+++ b/Anlab.Mvc/Views/Order/Document.cshtml
@@ -295,6 +295,10 @@
 </table>
 <br/><br/>
 <div style="page-break-before:always">&nbsp;</div>
+<div>I acknowledge that I have reviewed the sample amount guide and understand the sample quantities required for testing.  I understand that I may be responsible for charges incurred for work performed even if it does not result in any data due to insufficient sample amount submitted.</div>
+<div style="margin-top:8px;color:#fff;">**sample_amount_guide_link**</div>
+<div style="margin-top:2px;font-size:12px;">https://anlab.ucdavis.edu/forms-and-guides</div>
+<br /><br />
 <span>By signing below, I am authorizing work to be performed and confirming that I have proper authority to use the payment method indicated in this order.</span>
 <div>I am also agreeing to pay any applicable shipping, handling, or third party charges that may be incurred but not listed.</div>
 <br/><br />


### PR DESCRIPTION
Ensure signers are aware of sample quantity requirements and acknowledge potential charges for insufficient samples.